### PR TITLE
feat: support detached HEAD with new "release -d" option

### DIFF
--- a/src/SemanticRelease.CommitAnalyzer/DefaultPreConditions.cs
+++ b/src/SemanticRelease.CommitAnalyzer/DefaultPreConditions.cs
@@ -14,18 +14,18 @@ namespace SemanticRelease.CommitAnalyzer
             this._repository = repositoryProvider;
         }
 
-        public void Verify()
+        public void Verify(bool detachedHead)
         {
             var repoRef = _repository.RepositoryRef as ReleaseRepository<IRepository>;
 
             var repo = repoRef.GetRepositoryReference();
 
-            if (!repo.Head.FriendlyName.Equals(_repository.ReleaseBranch))
+            if (!detachedHead && !repo.Head.FriendlyName.Equals(_repository.ReleaseBranch))
             {
                 throw new Exception($"Wrong Branch: {repo.Head.FriendlyName} must be {_repository.ReleaseBranch} to deploy");
             }
 
-            if (!repo.Head.IsTracking)
+            if (!detachedHead && !repo.Head.IsTracking)
             {
                 throw new Exception("No remote found for current branch.");
             }

--- a/src/SemanticRelease.Core/cli/ReleaseCli.cs
+++ b/src/SemanticRelease.Core/cli/ReleaseCli.cs
@@ -17,7 +17,7 @@ namespace SemanticRelease.Core.CLI
         [Option("-f|--fail-on-no-release",  Description = "Return non-zero exit code when no release is required.")]
         public bool ThrowOnNoOp { get; set; }
 
-        [Option("-d|--detachedHead", Description = "Work with a detached HEAD (for example, when building on Azure pipelines)")]
+        [Option("-d|--detached-head", Description = "Work with a detached HEAD (for example, when building on Azure pipelines)")]
         public bool DetachedHead { get; set; }
 
         public ReleaseCli()

--- a/src/SemanticRelease.Core/cli/ReleaseCli.cs
+++ b/src/SemanticRelease.Core/cli/ReleaseCli.cs
@@ -17,6 +17,9 @@ namespace SemanticRelease.Core.CLI
         [Option("-f|--fail-on-no-release",  Description = "Return non-zero exit code when no release is required.")]
         public bool ThrowOnNoOp { get; set; }
 
+        [Option("-d|--detachedHead", Description = "Work with a detached HEAD (for example, when building on Azure pipelines)")]
+        public bool DetachedHead { get; set; }
+
         public ReleaseCli()
         {
             _fileSystem = new FileSystem();
@@ -32,7 +35,7 @@ namespace SemanticRelease.Core.CLI
                 var repository = new OnDiskGitRepository(workingDir, releaseBranch, _fileSystem);
 
                 var preconditions = new DefaultPreConditions(repository);
-                preconditions.Verify();
+                preconditions.Verify(DetachedHead);
 
                 var commitAnalyzer = new DefaultCommitAnalyzer(repository);
                 commitAnalyzer.CommitEvent += OnCommitEvent;

--- a/src/SemanticRelease.Extensibility/IPreConditionVerifier.cs
+++ b/src/SemanticRelease.Extensibility/IPreConditionVerifier.cs
@@ -2,6 +2,6 @@ namespace SemanticRelease.Extensibility
 {
     public interface IPreConditionVerifier
     {
-        void Verify();
+        void Verify(bool detachedHead);
     }
 }


### PR DESCRIPTION
Some build servers (for example Azure pipelines) get a specific hash instead of getting a branch. I added a new option "-d / --detachedHead" for this scenario, so that I can use semantic release with my azure pipeline build.